### PR TITLE
Add pagination to ListPets endpoint

### DIFF
--- a/controllers/controllers.js
+++ b/controllers/controllers.js
@@ -1,62 +1,67 @@
-const User = require("../models/User")
-const Foundation = require("../models/Foundation")
-const jwt = require("jsonwebtoken")
-const config = require("../config/index")
-const Pet = require("../models/Pet")
+const User = require("../models/User");
+const Foundation = require("../models/Foundation");
+const jwt = require("jsonwebtoken");
+const config = require("../config/index");
+const Pet = require("../models/Pet");
 
 const login = async (req, res) => {
-  const { email, password } = req.body
+  const { email, password } = req.body;
 
-  let user = await User.authenticate(email, password)
+  let user = await User.authenticate(email, password);
 
   if (user) {
-    const token = jwt.sign({ userId: user._id }, config.jwtKey)
-    res.json({ token, user })
+    const token = jwt.sign({ userId: user._id }, config.jwtKey);
+    res.json({ token, user });
   } else {
-    user = await Foundation.authenticate(email, password)
+    user = await Foundation.authenticate(email, password);
     if (user) {
-      const token = jwt.sign({ userId: user._id }, config.jwtKey)
-      res.json({ token, user })
+      const token = jwt.sign({ userId: user._id }, config.jwtKey);
+      res.json({ token, user });
     } else {
-      res.status(401).json({ error: "Invalid credentials" })
+      res.status(401).json({ error: "Invalid credentials" });
     }
   }
-}
+};
 
 const listFoundations = async (req, res, next) => {
   try {
     const foundations = await Foundation.find(
       {},
       { password: 0, __v: 0, role: 0 }
-    ).limit(10)
-    res.status(200).json(foundations)
+    ).limit(10);
+    res.status(200).json(foundations);
   } catch (e) {
-    return next(e)
+    return next(e);
   }
-}
+};
 
 const loadUser = async (req, res) => {
-  const { name, email, address, phoneNumber, role, photoUrl } = res.locals.user
-  res.json({ name, email, address, phoneNumber, role, photoUrl })
-}
+  const { name, email, address, phoneNumber, role, photoUrl } = res.locals.user;
+  res.json({ name, email, address, phoneNumber, role, photoUrl });
+};
 
 const listPets = async (req, res, next) => {
   try {
-    const pets = await Pet.find({ foundationId: req.params.id })
-    res.status(200).json(pets)
+    const page = req.query.page || 1;
+    const count = await Pet.count({ foundationId: req.params.id });
+    const pets = await Pet.find({ foundationId: req.params.id }, null, {
+      skip: (page - 1) * 10,
+      limit: 10,
+    });
+    res.status(200).json({ page, count, pets });
   } catch (e) {
-    next(e)
+    next(e);
   }
-}
+};
 
 const destroyPet = async (req, res, next) => {
   try {
-    await Pet.deleteOne({ _id: req.params.id })
-    res.status(204).end()
+    await Pet.deleteOne({ _id: req.params.id });
+    res.status(204).end();
   } catch (e) {
-    next(e)
+    next(e);
   }
-}
+};
 
 const createPet = async (req, res, next) => {
   try {
@@ -66,14 +71,14 @@ const createPet = async (req, res, next) => {
       photoUrl: req.body.photoUrl,
       age: req.body.age,
       foundationId: req.params.foundationId,
-    }
-    const pet = new Pet(data)
-    await pet.save()
-    res.status(201).json(pet)
+    };
+    const pet = new Pet(data);
+    await pet.save();
+    res.status(201).json(pet);
   } catch (e) {
-    next(e)
+    next(e);
   }
-}
+};
 
 module.exports = {
   listFoundations,
@@ -82,4 +87,4 @@ module.exports = {
   createPet,
   login,
   loadUser,
-}
+};


### PR DESCRIPTION
# Results Pagination

## Key Features
* The `listPets` endpoint checks if there is a `page` param in the query, otherwise it returns the first list of pets for the requestes foundation.
* The endpoint returns 10 results per page.

## Changes
* The endpoint now returns 2 extra values in the object, `count` which is the total count of results, and `page` which is the current page of the results.

## Preview

![imagen](https://user-images.githubusercontent.com/58634102/134045046-964a9be3-29c9-4c42-b8c9-1dbaabf2157f.png)
